### PR TITLE
Solve some deprecation warnings from Rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ you wish to login. You may have a method like this in a controller.
 ```ruby
 class AuthenticationController < ApplicationController
 
-  skip_before_filter :login_required
+  skip_before_action :login_required
 
   def login
     if request.post?
@@ -89,7 +89,7 @@ before every action in your application.
 ```ruby
 class ApplicationController < ActionController::Base
 
-  before_filter :login_required
+  before_action :login_required
 
   private
 
@@ -295,7 +295,7 @@ on every request to your application.
 ```ruby
 class ApplicationController < ActionController::Base
 
-  before_filter :check_two_factor_auth
+  before_action :check_two_factor_auth
 
   def check_two_factor_auth
     if logged_in? && current_user.has_two_factor_auth? && !auth_session.two_factored?
@@ -316,7 +316,7 @@ session as being verified with two factor auth.
 ```ruby
 class LoginController < ApplicationController
 
-  skip_before_filter :check_two_factor_auth
+  skip_before_action :check_two_factor_auth
 
   def two_factor_auth
     if user.verify_two_factor_token(params[:token])

--- a/lib/authie/controller_extension.rb
+++ b/lib/authie/controller_extension.rb
@@ -5,7 +5,7 @@ module Authie
 
     def self.included(base)
       base.helper_method :logged_in?, :current_user, :auth_session
-      base.before_filter :set_browser_id, :touch_auth_session
+      base.before_action :set_browser_id, :touch_auth_session
     end
 
     private

--- a/test/tests/controller_extension_test.rb
+++ b/test/tests/controller_extension_test.rb
@@ -2,12 +2,12 @@ require 'authie/controller_extension'
 
 class ExtendedController < FakeController
 
-  def self.before_filters
-    @before_filters ||= []
+  def self.before_actions
+    @before_actions ||= []
   end
 
-  def self.before_filter(*names)
-    names.each { |n| before_filters << n }
+  def self.before_action(*names)
+    names.each { |n| before_actions << n }
   end
 
   def self.helper_methods
@@ -32,9 +32,9 @@ class ControllerExtensionTest < Minitest::Test
     assert_equal Authie::ControllerDelegate, @controller.send(:auth_session_delegate).class
   end
 
-  def test_before_filters_are_added
-    assert @controller.class.before_filters.include?(:set_browser_id)
-    assert @controller.class.before_filters.include?(:touch_auth_session)
+  def test_before_actions_are_added
+    assert @controller.class.before_actions.include?(:set_browser_id)
+    assert @controller.class.before_actions.include?(:touch_auth_session)
   end
 
   def test_helper_methods_are_added


### PR DESCRIPTION
Rails 5 deprecates `before_filter`, and Rails 5.1 will remove it. The two functions are exactly the same except in name. This branch converts all `before_filter`s to `before_action`s.

