### PR TITLE
Fix autoload path

### DIFF
--- a/lib/authie/engine.rb
+++ b/lib/authie/engine.rb
@@ -3,7 +3,7 @@ module Authie
 
     engine_name 'authie'
 
-    config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    config.autoload_paths += Dir["#{config.root}/lib"]
 
     initializer 'authie.initialize' do |app|
       ActiveSupport.on_load :action_controller do


### PR DESCRIPTION
Fixes the uninitialized constant error when under zeitwerk.  Closes #17 by implementing the fix that @fxn came up with.