### PR TITLE
fix: correctly set cookie when reverting from impersonated session

### DIFF
--- a/test/tests/session_test.rb
+++ b/test/tests/session_test.rb
@@ -299,6 +299,7 @@ class SessionTest < Minitest::Test
     # Test that the controller's session cookie is the new session
     assert_equal new_session.token_hash, Authie::Session.hash_token(controller.cookies[:user_session])
     # Test reverting to the parent controller
+    new_session.reload
     assert original_session = new_session.revert_to_parent!
     assert_equal original_session, session
     assert_equal session.token_hash, Authie::Session.hash_token(controller.cookies[:user_session])


### PR DESCRIPTION
Closes #21

Impersonation seems to have been broken in 8717b6a7abb7f4e992d3cb037058b5810ea18020, due to the new `temporary_token` not being available when `revert_to_parent!` is called. 

I've fixed this by storing the old `user_session` cookie value in a new `parent_user_session` cookie when `impersonate!` is called. This cookie value is used to correctly restore `user_session` when `revert_to_parent!` is called, and is then deleted.