### PR TITLE
Make the Session Cookie name configurable

### DIFF
--- a/lib/authie/config.rb
+++ b/lib/authie/config.rb
@@ -6,6 +6,7 @@ module Authie
     attr_accessor :persistent_session_length
     attr_accessor :sudo_session_timeout
     attr_accessor :browser_id_cookie_name
+    attr_accessor :session_cookie_name
     attr_accessor :session_token_length
     attr_accessor :extend_session_expiry_on_touch
 
@@ -14,6 +15,7 @@ module Authie
       @persistent_session_length = 2.months
       @sudo_session_timeout = 10.minutes
       @browser_id_cookie_name = :browser_id
+      @session_cookie_name = :user_session
       @session_token_length = 64
       @extend_session_expiry_on_touch = false
     end

--- a/lib/authie/session.rb
+++ b/lib/authie/session.rb
@@ -79,7 +79,7 @@ module Authie
     # @return [Authie::Session]
     def invalidate
       @session.invalidate!
-      cookies.delete(:user_session)
+      cookies.delete(Authie.config.session_cookie_name)
       self
     end
 
@@ -153,7 +153,7 @@ module Authie
     private
 
     def set_cookie(value = @session.temporary_token)
-      cookies[:user_session] = {
+      cookies[Authie.config.session_cookie_name] = {
         value: value,
         secure: @controller.request.ssl?,
         httponly: true,
@@ -260,12 +260,12 @@ module Authie
       # @return [Authie::Session]
       def get_session(controller)
         cookies = controller.send(:cookies)
-        return nil if cookies[:user_session].blank?
+        return nil if cookies[Authie.config.session_cookie_name].blank?
 
-        session = SessionModel.find_session_by_token(cookies[:user_session])
+        session = SessionModel.find_session_by_token(cookies[Authie.config.session_cookie_name])
         return nil if session.blank?
 
-        session.temporary_token = cookies[:user_session]
+        session.temporary_token = cookies[Authie.config.session_cookie_name]
         new(controller, session)
       end
 

--- a/spec/integration/controller_extension_spec.rb
+++ b/spec/integration/controller_extension_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe PagesController, type: :controller do
       session.save!
     end
     cookies[:browser_id] = browser_id
-    cookies[:user_session] = session.temporary_token
+    cookies[Authie.config.session_cookie_name] = session.temporary_token
     session
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -68,4 +68,15 @@ RSpec.describe Authie::Config do
       expect(config.browser_id_cookie_name).to eq :auth_browser_id
     end
   end
+
+  describe '#session_cookie_name' do
+    it 'returns the default value' do
+      expect(config.session_cookie_name).to eq :user_session
+    end
+
+    it 'returns an overriden value' do
+      config.session_cookie_name = :auth_user_session
+      expect(config.session_cookie_name).to eq :auth_user_session
+    end
+  end
 end

--- a/spec/lib/controller_delegate_spec.rb
+++ b/spec/lib/controller_delegate_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Authie::ControllerDelegate do
         session = delegate.create_auth_session(user)
         expect(session).to be_a Authie::Session
         expect(session.user).to eq user
-        expect(controller.send(:cookies)[:user_session]).to eq session.temporary_token
+        expect(controller.send(:cookies)[Authie.config.session_cookie_name]).to eq session.temporary_token
       end
 
       it 'can receive other options for the session too' do

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -280,10 +280,10 @@ RSpec.describe Authie::Session do
     end
 
     it 'updates the cookie' do
-      original_cookie_value = controller.send(:cookies)[:user_session]
+      original_cookie_value = controller.send(:cookies)[Authie.config.session_cookie_name]
       session.reset_token
-      expect(controller.send(:cookies)[:user_session]).to_not eq original_cookie_value
-      expect(controller.send(:cookies)[:user_session]).to eq session.temporary_token
+      expect(controller.send(:cookies)[Authie.config.session_cookie_name]).to_not eq original_cookie_value
+      expect(controller.send(:cookies)[Authie.config.session_cookie_name]).to eq session.temporary_token
     end
 
     it 'returns itself' do
@@ -350,18 +350,18 @@ RSpec.describe Authie::Session do
     end
 
     it 'returns nil if there is no session matching the value in the cookie' do
-      controller.send(:cookies)[:user_session] = 'invalid'
+      controller.send(:cookies)[Authie.config.session_cookie_name] = 'invalid'
       expect(described_class.get_session(controller)).to be nil
     end
 
     it 'returns a session object if a session is found' do
-      controller.send(:cookies)[:user_session] = session_model.temporary_token
+      controller.send(:cookies)[Authie.config.session_cookie_name] = session_model.temporary_token
       expect(described_class.get_session(controller)).to be_a Authie::Session
       expect(described_class.get_session(controller).session).to eq session_model
     end
 
     it 'sets the temporary token on the underlying session' do
-      controller.send(:cookies)[:user_session] = session_model.temporary_token
+      controller.send(:cookies)[Authie.config.session_cookie_name] = session_model.temporary_token
       expect(described_class.get_session(controller).session.temporary_token).to eq session_model.temporary_token
     end
   end


### PR DESCRIPTION
### Context
* Introduces configurable Session Cookie name
* Keeps Default Session Cookie name to `user_session`
* Adds new configuration spec
* Updates existing specs

### Purpose
Some Apps prefer to name the cookies differently

### Changelog
* Adds `Authie.Config.session_cookie_name`
* Adds `Authie.Config.session_cookie_name=`
