### PR TITLE
Fix SessionModel#where in Rack controller

### DIFF
--- a/lib/authie/rack_controller.rb
+++ b/lib/authie/rack_controller.rb
@@ -27,7 +27,7 @@ module Authie
     def set_browser_id
       until cookies[:browser_id]
         proposed_browser_id = SecureRandom.uuid
-        unless Session.where(browser_id: proposed_browser_id).exists?
+        unless SessionModel.where(browser_id: proposed_browser_id).exists?
           cookies[:browser_id] = { value: proposed_browser_id, expires: 20.years.from_now }
         end
       end


### PR DESCRIPTION
This is a one-line PR to fix the query which finds sessions for a given `browser_id` in the Rack controller helpers.

I use this to authenticate a user in a routing constraint (so that only authorised users can access Sidekiq) and this seems to fix it for me.

I didn't see any tests in `spec/` that looked like they covered this, but if there are some I can have a crack at updating those too!