### PR TITLE
Update README to target authie v5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The design goals behind Authie are:
 As usual, just pop this in your Gemfile:
 
 ```ruby
-gem 'authie', '~> 4.0'
+gem 'authie', '~> 5.0'
 ```
 
 You will then need add the database tables Authie needs to your database. You


### PR DESCRIPTION
First time using this gem, thank you.

Rails 8 requires the latest version (5.0.0) to be installed in order to work.