### PR TITLE
feat(session/config): add configurable request ip lookup method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'appraisal', '2.4.1'
+gem 'appraisal', '2.5.0'
 gem 'rails', '>= 5.0', '< 9.0'
 gem 'rspec'
 gem 'rspec-core'

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "2.4.1"
+gem "appraisal", "2.5.0"
 gem "rails", "~> 7.1.0"
 gem "rspec"
 gem "rspec-core"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "2.4.1"
+gem "appraisal", "2.5.0"
 gem "rails", "~> 7.2.0"
 gem "rspec"
 gem "rspec-core"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "2.4.1"
+gem "appraisal", "2.5.0"
 gem "rails", "~> 8.0.0"
 gem "rspec"
 gem "rspec-core"

--- a/lib/authie/config.rb
+++ b/lib/authie/config.rb
@@ -10,6 +10,7 @@ module Authie
     attr_accessor :extend_session_expiry_on_touch
     attr_accessor :lookup_ip_country_backend
     attr_accessor :serialize_coder
+    attr_accessor :ip_lookup_method
 
     def initialize
       set_defaults
@@ -21,6 +22,14 @@ module Authie
       @lookup_ip_country_backend.call(ip)
     end
 
+    def resolve_ip(request)
+      if @ip_lookup_method.is_a?(Proc)
+        @ip_lookup_method.call(request)
+      else
+        request.public_send(@ip_lookup_method)
+      end
+    end
+
     def set_defaults
       @session_inactivity_timeout = 12.hours
       @persistent_session_length = 2.months
@@ -30,6 +39,7 @@ module Authie
       @extend_session_expiry_on_touch = false
       @lookup_ip_country_backend = nil
       @serialize_coder = ActiveRecord::Coders::YAMLColumn
+      @ip_lookup_method = :ip
     end
   end
 

--- a/lib/authie/session.rb
+++ b/lib/authie/session.rb
@@ -96,10 +96,11 @@ module Authie
     # @return [Authie::Session]
     def touch
       @session.last_activity_at = Time.now
-      if @controller.request.ip != @session.last_activity_ip
-        @session.last_activity_ip_country = Authie.config.lookup_ip_country(@controller.request.ip)
+      remote_ip = Authie.config.resolve_ip(@controller.request)
+      if remote_ip != @session.last_activity_ip
+        @session.last_activity_ip_country = Authie.config.lookup_ip_country(remote_ip)
       end
-      @session.last_activity_ip = @controller.request.ip
+      @session.last_activity_ip = remote_ip
 
       @session.last_activity_path = @controller.request.path
       @session.requests += 1
@@ -127,8 +128,9 @@ module Authie
     # @return [Authie::Session]
     def mark_as_two_factored(skip: nil)
       @session.two_factored_at = Time.now
-      @session.two_factored_ip = @controller.request.ip
-      @session.two_factored_ip_country = Authie.config.lookup_ip_country(@controller.request.ip)
+      remote_ip = Authie.config.resolve_ip(@controller.request)
+      @session.two_factored_ip = remote_ip
+      @session.two_factored_ip_country = Authie.config.lookup_ip_country(remote_ip)
       @session.skip_two_factor = skip unless skip.nil?
       @session.save!
       Authie.notify(:mark_as_two_factor, session: self)
@@ -248,7 +250,7 @@ module Authie
         session.user = user
         session.browser_id = cookies[:browser_id]
         session.login_at = Time.now
-        session.login_ip = controller.request.ip
+        session.login_ip = Authie.config.resolve_ip(controller.request)
         session.login_ip_country = Authie.config.lookup_ip_country(session.login_ip)
         session.host = controller.request.host
         session.user_agent = controller.request.user_agent

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -68,4 +68,41 @@ RSpec.describe Authie::Config do
       expect(config.browser_id_cookie_name).to eq :auth_browser_id
     end
   end
+
+  describe '#ip_lookup_method' do
+    it 'returns the default value' do
+      expect(config.ip_lookup_method).to eq :ip
+    end
+
+    it 'returns an overriden value' do
+      config.ip_lookup_method = :remote_ip
+      expect(config.ip_lookup_method).to eq :remote_ip
+    end
+  end
+
+  describe '#resolve_ip' do
+    let(:request) do
+      double('request', remote_ip: '1.2.3.4', ip: '5.6.7.8', custom_ip: '9.10.11.12')
+    end
+
+    it 'returns remote_ip when ip_lookup_method is :remote_ip' do
+      config.ip_lookup_method = :remote_ip
+      expect(config.resolve_ip(request)).to eq '1.2.3.4'
+    end
+
+    it 'returns ip when ip_lookup_method is :ip' do
+      config.ip_lookup_method = :ip
+      expect(config.resolve_ip(request)).to eq '5.6.7.8'
+    end
+
+    it 'calls any method name on the request object' do
+      config.ip_lookup_method = :custom_ip
+      expect(config.resolve_ip(request)).to eq '9.10.11.12'
+    end
+
+    it 'calls a proc with the request object' do
+      config.ip_lookup_method = ->(req) { req.remote_ip.reverse }
+      expect(config.resolve_ip(request)).to eq '4.3.2.1'
+    end
+  end
 end

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -137,20 +137,20 @@ RSpec.describe Authie::Session do
     end
 
     it 'sets the last activity IP' do
-      allow(controller.request).to receive(:ip).and_return('1.2.3.4')
+      allow(Authie.config).to receive(:resolve_ip).and_return('1.2.3.4')
       session.touch
       expect(session.last_activity_ip).to eq '1.2.3.4'
     end
 
     it 'sets the last activity IP country' do
-      allow(controller.request).to receive(:ip).and_return('1.2.3.4')
+      allow(Authie.config).to receive(:resolve_ip).and_return('1.2.3.4')
       allow(Authie.config).to receive(:lookup_ip_country).with('1.2.3.4').and_return('FR')
       session.touch
       expect(session.last_activity_ip_country).to eq 'FR'
     end
 
     it 'does not lookup an IP if the last activity IP does not change' do
-      allow(controller.request).to receive(:ip).and_return('1.2.3.4')
+      allow(Authie.config).to receive(:resolve_ip).and_return('1.2.3.4')
       session.update!(last_activity_ip: '1.2.3.4', last_activity_ip_country: 'FR')
       expect(Authie.config).to_not receive(:lookup_ip_country)
       session.touch
@@ -260,13 +260,13 @@ RSpec.describe Authie::Session do
     end
 
     it 'sets the ip address' do
-      allow(controller.request).to receive(:ip).and_return('1.2.3.4')
+      allow(Authie.config).to receive(:resolve_ip).and_return('1.2.3.4')
       session.mark_as_two_factored
       expect(session.two_factored_ip).to eq '1.2.3.4'
     end
 
     it 'sets the ip address country' do
-      allow(controller.request).to receive(:ip).and_return('1.2.3.4')
+      allow(Authie.config).to receive(:resolve_ip).and_return('1.2.3.4')
       allow(Authie.config).to receive(:lookup_ip_country).with('1.2.3.4').and_return('AU')
       session.mark_as_two_factored
       expect(session.two_factored_ip_country).to eq 'AU'
@@ -329,7 +329,7 @@ RSpec.describe Authie::Session do
   describe '.start' do
     it 'creates a new session with details from the request' do
       time = Time.new(2022, 3, 4, 2, 31, 22)
-      allow(controller.request).to receive(:ip).and_return('1.2.3.4')
+      allow(Authie.config).to receive(:resolve_ip).and_return('1.2.3.4')
       Timecop.freeze(time) do
         session = described_class.start(controller, user: user)
         expect(session).to be_a Authie::Session
@@ -343,8 +343,8 @@ RSpec.describe Authie::Session do
     end
 
     it 'adds the login IP coutnry' do
+      allow(Authie.config).to receive(:resolve_ip).and_return('1.2.3.4')
       allow(Authie.config).to receive(:lookup_ip_country).with('1.2.3.4').and_return('GB')
-      allow(controller.request).to receive(:ip).and_return('1.2.3.4')
       session = described_class.start(controller, user: user)
       expect(session).to be_a Authie::Session
       expect(session.session.login_ip_country).to eq 'GB'


### PR DESCRIPTION
Implement a flexible IP resolution method for sessions. This allows
customization of how IP addresses are retrieved from request objects,
supporting different Rails environments and custom IP extraction
strategies.

Adds a new configuration option called `ip_lookup_method` with support
for method names as symbols and procs for dynamic lookup. The default
value is `:ip`, ensuring backwards compatibility.