### PR TITLE
feat: cookie_domain config to support subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,19 @@ class LoginController < ApplicationController
 end
 ```
 
+### Sharing sessions across subdomains
+
+By default, Authie sets cookies without an explicit `domain`, which scopes
+them to the exact host that issued them. If you need a single session to
+be valid across multiple subdomains (for example `app.example.com` and
+`admin.example.com`) you can configure a cookie domain. Both the
+`user_session` cookie and the `browser_id` cookie will then be set with
+this domain.
+
+```ruby
+Authie.config.cookie_domain = '.example.com'
+```
+
 ## Storing IP address countries
 
 Authie has support for storing the country that an IP address is located in whenever they are saved to the database. To use this, you need to specify a backend to use in the Authie configuration. The backend should respond to `#call(ip_address)`.

--- a/lib/authie/config.rb
+++ b/lib/authie/config.rb
@@ -11,6 +11,7 @@ module Authie
     attr_accessor :lookup_ip_country_backend
     attr_accessor :serialize_coder
     attr_accessor :ip_lookup_method
+    attr_accessor :cookie_domain
 
     def initialize
       set_defaults
@@ -40,6 +41,7 @@ module Authie
       @lookup_ip_country_backend = nil
       @serialize_coder = ActiveRecord::Coders::YAMLColumn
       @ip_lookup_method = :ip
+      @cookie_domain = nil
     end
   end
 

--- a/lib/authie/controller_delegate.rb
+++ b/lib/authie/controller_delegate.rb
@@ -28,12 +28,14 @@ module Authie
         proposed_browser_id = SecureRandom.uuid
         next if Authie::SessionModel.where(browser_id: proposed_browser_id).exists?
 
-        cookies[Authie.config.browser_id_cookie_name] = {
+        cookie_options = {
           value: proposed_browser_id,
           expires: 5.years.from_now,
           httponly: true,
           secure: @controller.request.ssl?
         }
+        cookie_options[:domain] = Authie.config.cookie_domain if Authie.config.cookie_domain
+        cookies[Authie.config.browser_id_cookie_name] = cookie_options
         Authie.notify(:set_browser_id,
                       browser_id: proposed_browser_id,
                       controller: @controller)

--- a/lib/authie/rack_controller.rb
+++ b/lib/authie/rack_controller.rb
@@ -28,7 +28,9 @@ module Authie
       until cookies[:browser_id]
         proposed_browser_id = SecureRandom.uuid
         unless SessionModel.where(browser_id: proposed_browser_id).exists?
-          cookies[:browser_id] = { value: proposed_browser_id, expires: 20.years.from_now }
+          cookie_options = { value: proposed_browser_id, expires: 20.years.from_now }
+          cookie_options[:domain] = Authie.config.cookie_domain if Authie.config.cookie_domain
+          cookies[:browser_id] = cookie_options
         end
       end
     end

--- a/lib/authie/session.rb
+++ b/lib/authie/session.rb
@@ -79,7 +79,10 @@ module Authie
     # @return [Authie::Session]
     def invalidate
       @session.invalidate!
+      # Always invalidate the cookie on the current domain. If a cookie_domain is set, also
+      # invalidate the cookie on that domain to ensure it is removed in all cases.
       cookies.delete(:user_session)
+      cookies.delete(:user_session, domain: Authie.config.cookie_domain) if Authie.config.cookie_domain
       self
     end
 
@@ -160,12 +163,14 @@ module Authie
     private
 
     def set_cookie(value = @session.temporary_token)
-      cookies[:user_session] = {
+      cookie_options = {
         value: value,
         secure: @controller.request.ssl?,
         httponly: true,
         expires: @session.expires_at
       }
+      cookie_options[:domain] = Authie.config.cookie_domain if Authie.config.cookie_domain
+      cookies[:user_session] = cookie_options
       Authie.notify(:cookie_updated, session: session)
       true
     end
@@ -215,10 +220,20 @@ module Authie
     end
 
     def validate_host
-      if @session.host && @session.host != @controller.request.host
+      request_host = @controller.request.host
+      matched = if Authie.config.cookie_domain
+                  suffix = Authie.config.cookie_domain.delete_prefix('.')
+                  request_host == suffix || request_host.end_with?(".#{suffix}")
+                elsif @session.host
+                  @session.host == request_host
+                else
+                  true
+                end
+
+      unless matched
         invalidate
         Authie.notify(:host_mismatch_error, session: self)
-        raise HostMismatch.new("Session was created on #{@session.host} but accessed using #{@controller.request.host}",
+        raise HostMismatch.new("Session was created on #{@session.host} but accessed using #{request_host}",
                                self)
       end
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe Authie::Config do
     end
   end
 
+  describe '#cookie_domain' do
+    it 'returns nil by default' do
+      expect(config.cookie_domain).to be nil
+    end
+
+    it 'returns an overriden value' do
+      config.cookie_domain = '.example.com'
+      expect(config.cookie_domain).to eq '.example.com'
+    end
+  end
+
   describe '#ip_lookup_method' do
     it 'returns the default value' do
       expect(config.ip_lookup_method).to eq :ip

--- a/spec/lib/controller_delegate_spec.rb
+++ b/spec/lib/controller_delegate_spec.rb
@@ -118,6 +118,17 @@ RSpec.describe Authie::ControllerDelegate do
       expect(set_cookies['browser_id'][:expires]).to eq time + 5.years
     end
 
+    it 'does not set a cookie domain by default' do
+      delegate.set_browser_id
+      expect(set_cookies['browser_id']).to_not have_key(:domain)
+    end
+
+    it 'sets the cookie domain when configured' do
+      allow(Authie.config).to receive(:cookie_domain).and_return('.example.com')
+      delegate.set_browser_id
+      expect(set_cookies['browser_id'][:domain]).to eq '.example.com'
+    end
+
     it 'does not use brower IDs that already exist' do
       existing_session = Authie::SessionModel.create!(browser_id: SecureRandom.uuid)
       allow(SecureRandom).to receive(:uuid).and_return(existing_session.browser_id, SecureRandom.uuid)

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -96,6 +96,44 @@ RSpec.describe Authie::Session do
       controller.request.headers['Host'] = 'example.com'
       expect(session.validate).to eq session
     end
+
+    shared_examples 'a configured cookie domain' do
+      it 'allows requests on the apex domain' do
+        session_model.update!(host: 'app.example.com')
+        controller.request.headers['Host'] = 'example.com'
+        expect(session.validate).to eq session
+      end
+
+      it 'allows requests on a subdomain' do
+        session_model.update!(host: 'app.example.com')
+        controller.request.headers['Host'] = 'admin.example.com'
+        expect(session.validate).to eq session
+      end
+
+      it 'rejects requests on a host that merely ends with the suffix' do
+        session_model.update!(host: 'app.example.com')
+        controller.request.headers['Host'] = 'evil-example.com'
+        expect { session.validate }.to raise_error Authie::Session::HostMismatch
+      end
+
+      it 'rejects requests on an unrelated host' do
+        session_model.update!(host: 'app.example.com')
+        controller.request.headers['Host'] = 'attacker.test'
+        expect { session.validate }.to raise_error Authie::Session::HostMismatch
+      end
+    end
+
+    context 'when cookie_domain is set with a leading dot' do
+      before { allow(Authie.config).to receive(:cookie_domain).and_return('.example.com') }
+
+      it_behaves_like 'a configured cookie domain'
+    end
+
+    context 'when cookie_domain is set without a leading dot' do
+      before { allow(Authie.config).to receive(:cookie_domain).and_return('example.com') }
+
+      it_behaves_like 'a configured cookie domain'
+    end
   end
 
   describe '#persist' do
@@ -127,6 +165,21 @@ RSpec.describe Authie::Session do
       expect(controller.send(:cookies)['user_session']).to eq session_model.temporary_token
       session.invalidate
       expect(controller.send(:cookies)['user_session']).to be nil
+    end
+
+    it 'deletes both the host-scoped and domain-scoped cookies when a cookie_domain is configured' do
+      allow(Authie.config).to receive(:cookie_domain).and_return('.example.com')
+      session.start
+      expect(controller.send(:cookies)).to receive(:delete).with(:user_session).ordered
+      expect(controller.send(:cookies)).to receive(:delete).with(:user_session, domain: '.example.com').ordered
+      session.invalidate
+    end
+
+    it 'only deletes the host-scoped cookie when no cookie_domain is configured' do
+      session.start
+      expect(controller.send(:cookies)).to receive(:delete).with(:user_session)
+      expect(controller.send(:cookies)).to_not receive(:delete).with(:user_session, anything)
+      session.invalidate
     end
   end
 
@@ -323,6 +376,17 @@ RSpec.describe Authie::Session do
       expect(Authie).to receive(:notify) # for cookies
       expect(Authie).to receive(:notify).with(:session_start, session: session)
       session.start
+    end
+
+    it 'does not set a cookie domain by default' do
+      session.start
+      expect(set_cookies['user_session']).to_not have_key(:domain)
+    end
+
+    it 'sets the cookie domain when configured' do
+      allow(Authie.config).to receive(:cookie_domain).and_return('.example.com')
+      session.start
+      expect(set_cookies['user_session'][:domain]).to eq '.example.com'
     end
   end
 


### PR DESCRIPTION
By default, Authie sets cookies without an explicit `domain`, which scopes
them to the exact host that issued them. If you need a single session to
be valid across multiple subdomains (for example `app.example.com` and
`admin.example.com`) you can configure a cookie domain. Both the
`user_session` cookie and the `browser_id` cookie will then be set with
this domain.

```ruby
Authie.config.cookie_domain = '.example.com'
```